### PR TITLE
fix: add unsafe before old lifecycle methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default class Lottie extends React.Component {
     this.registerEvents(eventListeners);
   }
 
-  componentWillUpdate(nextProps /* , nextState */) {
+  UNSAFE_componentWillUpdate(nextProps /* , nextState */) {
     /* Recreate the animation handle if the data is changed */
     if (this.options.animationData !== nextProps.options.animationData) {
       this.deRegisterEvents(this.props.eventListeners);

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -117,7 +117,7 @@ describe('react-lottie', () => {
         component.instance().registerEvents = registerEventsSpy;
         component.update();
 
-        component.instance().componentWillUpdate({
+        component.instance().UNSAFE_componentWillUpdate({
           options: {
             ...defaultOptions,
             animationData: beatingHeart,


### PR DESCRIPTION
This will resolve a console warning in modern react versions.